### PR TITLE
Add support for year selection

### DIFF
--- a/src/Runner/Program.cs
+++ b/src/Runner/Program.cs
@@ -1,66 +1,71 @@
 ﻿using AoCHelper;
 using System.Reflection;
 
-Dictionary<uint, Assembly> assemblies = new Dictionary<uint, Assembly>
+var assembliesByYear = new Dictionary<uint, Assembly>
 {
-    { 2020, Assembly.GetAssembly(typeof(AoC_2020.Base2020Day))! },
-    { 2021, Assembly.GetAssembly(typeof(AoC_2021.Base2021Day))! },
-    { 2022, Assembly.GetAssembly(typeof(AoC_2022.Day02))! }
+    [2020] = Assembly.GetAssembly(typeof(AoC_2020.Base2020Day))!,
+    [2021] = Assembly.GetAssembly(typeof(AoC_2021.Base2021Day))!,
+    [2022] = Assembly.GetAssembly(typeof(AoC_2022.Day02))!
 };
 
-List<Assembly> GetAssemblies(uint? year = null)
-{
-    if (!year.HasValue) return assemblies.Values.ToList();
+List<Assembly> Assemblies(uint year) =>
+    assembliesByYear.TryGetValue(year, out var assembly)
+        ? [assembly]
+        : [];
 
-    return assemblies.TryGetValue(year.Value, out var assembly)
-        ? new List<Assembly> { assembly }
-        : new List<Assembly>();
-}
-
-uint year;
 if (args.Length == 0)
 {
     await Solver.SolveLast(opt =>
     {
         opt.ClearConsole = false;
-        opt.ProblemAssemblies = [.. GetAssemblies(), .. opt.ProblemAssemblies];
+        opt.ProblemAssemblies = [.. assembliesByYear.Values, .. opt.ProblemAssemblies];
     });
 }
-else if (args.Length == 1 && args[0].Contains("all", StringComparison.CurrentCultureIgnoreCase))
+else if (args.Length == 1)
+{
+    ICollection<Assembly> yearAssemblies = [];
+
+    if (args[0].Contains("all", StringComparison.CurrentCultureIgnoreCase))
+    {
+        yearAssemblies = assembliesByYear.Values;
+    }
+    else if (uint.TryParse(args[0], out var year))
+    {
+        yearAssemblies = Assemblies(year);
+    }
+
+    if (yearAssemblies.Count > 0)
+    {
+        await Solver.SolveAll(opt =>
+        {
+            opt.ShowConstructorElapsedTime = true;
+            opt.ShowTotalElapsedTimePerDay = true;
+            opt.ProblemAssemblies = [.. assembliesByYear.Values, .. opt.ProblemAssemblies];
+        });
+    }
+}
+else if (args.Length == 2 &&
+    (args[0].Contains("all", StringComparison.CurrentCultureIgnoreCase) || args[1].Contains("all", StringComparison.CurrentCultureIgnoreCase))
+    && (uint.TryParse(args[0], out var year) || uint.TryParse(args[1], out year)))
 {
     await Solver.SolveAll(opt =>
     {
         opt.ShowConstructorElapsedTime = true;
         opt.ShowTotalElapsedTimePerDay = true;
-        opt.ProblemAssemblies = [.. GetAssemblies(), .. opt.ProblemAssemblies];
-    });
-}
-else if (args.Length == 1 && uint.TryParse(args[0], out year))
-{
-    await Solver.SolveLast(opt =>
-    {
-        opt.ShowConstructorElapsedTime = true;
-        opt.ShowTotalElapsedTimePerDay = true;
-        opt.ProblemAssemblies = [.. GetAssemblies(year), .. opt.ProblemAssemblies];
-    });
-}
-else if (args.Length == 2 && uint.TryParse(args[0], out year)
-                          && args[1].Contains("all", StringComparison.CurrentCultureIgnoreCase))
-{
-    await Solver.SolveAll(opt =>
-    {
-        opt.ShowConstructorElapsedTime = true;
-        opt.ShowTotalElapsedTimePerDay = true;
-        opt.ProblemAssemblies = [.. GetAssemblies(year), .. opt.ProblemAssemblies];
+        opt.ProblemAssemblies = [.. Assemblies(year), .. opt.ProblemAssemblies];
     });
 }
 else
 {
-    if (!uint.TryParse(args[0], out year)) year = 0;
+    if (uint.TryParse(args[0], out year))
+    {
+        var indexes = args[1..]
+            .Select(arg => uint.TryParse(arg, out var index)
+                ? index
+                : uint.MaxValue);
 
-    var indexes = args.Skip(1).Select(arg => uint.TryParse(arg, out var index) ? index : uint.MaxValue);
-
-    await Solver.Solve(
-        indexes.Where(i => i < uint.MaxValue),
-        opt => opt.ProblemAssemblies = [.. GetAssemblies(year), .. opt.ProblemAssemblies]);
+        await Solver.Solve(
+            indexes.Where(i => i < uint.MaxValue),
+            opt => opt.ProblemAssemblies = [.. Assemblies(year), .. opt.ProblemAssemblies]);
+    }
 }

--- a/src/Runner/Program.cs
+++ b/src/Runner/Program.cs
@@ -1,18 +1,29 @@
 ﻿using AoCHelper;
 using System.Reflection;
 
-List<Assembly> assemblies = [
-    Assembly.GetAssembly(typeof(AoC_2020.Base2020Day))!,
-    Assembly.GetAssembly(typeof(AoC_2021.Base2021Day))!,
-    Assembly.GetAssembly(typeof(AoC_2022.Day02))!
-];
+Dictionary<uint, Assembly> assemblies = new Dictionary<uint, Assembly>
+{
+    { 2020, Assembly.GetAssembly(typeof(AoC_2020.Base2020Day))! },
+    { 2021, Assembly.GetAssembly(typeof(AoC_2021.Base2021Day))! },
+    { 2022, Assembly.GetAssembly(typeof(AoC_2022.Day02))! }
+};
 
+List<Assembly> GetAssemblies(uint? year = null)
+{
+    if (!year.HasValue) return assemblies.Values.ToList();
+
+    return assemblies.TryGetValue(year.Value, out var assembly)
+        ? new List<Assembly> { assembly }
+        : new List<Assembly>();
+}
+
+uint year;
 if (args.Length == 0)
 {
     await Solver.SolveLast(opt =>
     {
         opt.ClearConsole = false;
-        opt.ProblemAssemblies = [.. assemblies, .. opt.ProblemAssemblies];
+        opt.ProblemAssemblies = [.. GetAssemblies(), .. opt.ProblemAssemblies];
     });
 }
 else if (args.Length == 1 && args[0].Contains("all", StringComparison.CurrentCultureIgnoreCase))
@@ -21,14 +32,35 @@ else if (args.Length == 1 && args[0].Contains("all", StringComparison.CurrentCul
     {
         opt.ShowConstructorElapsedTime = true;
         opt.ShowTotalElapsedTimePerDay = true;
-        opt.ProblemAssemblies = [.. assemblies, .. opt.ProblemAssemblies];
+        opt.ProblemAssemblies = [.. GetAssemblies(), .. opt.ProblemAssemblies];
+    });
+}
+else if (args.Length == 1 && uint.TryParse(args[0], out year))
+{
+    await Solver.SolveLast(opt =>
+    {
+        opt.ShowConstructorElapsedTime = true;
+        opt.ShowTotalElapsedTimePerDay = true;
+        opt.ProblemAssemblies = [.. GetAssemblies(year), .. opt.ProblemAssemblies];
+    });
+}
+else if (args.Length == 2 && uint.TryParse(args[0], out year)
+                          && args[1].Contains("all", StringComparison.CurrentCultureIgnoreCase))
+{
+    await Solver.SolveAll(opt =>
+    {
+        opt.ShowConstructorElapsedTime = true;
+        opt.ShowTotalElapsedTimePerDay = true;
+        opt.ProblemAssemblies = [.. GetAssemblies(year), .. opt.ProblemAssemblies];
     });
 }
 else
 {
-    var indexes = args.Select(arg => uint.TryParse(arg, out var index) ? index : uint.MaxValue);
+    if (!uint.TryParse(args[0], out year)) year = 0;
+
+    var indexes = args.Skip(1).Select(arg => uint.TryParse(arg, out var index) ? index : uint.MaxValue);
 
     await Solver.Solve(
         indexes.Where(i => i < uint.MaxValue),
-        opt => opt.ProblemAssemblies = [.. assemblies, .. opt.ProblemAssemblies]);
+        opt => opt.ProblemAssemblies = [.. GetAssemblies(year), .. opt.ProblemAssemblies]);
 }


### PR DESCRIPTION
Add option to select a year by providing it as the first argument.

Possible arguments and what they do:
- No arguments -  Solve last problem.
- all - Solve all problems.
- \<year> - Solve last problem of given year.
- \<year> all - Solve all problems of given year.
- \<year> \<problem1> ... \<problemN> -  Solve given problems of given year.

Replace assemblies list with dictionary and GetAssemblies method to get all assemblies or only the ones of the type of the given year.

The reason I suggest this change is because I wanted to solve a specific problem, but the runner ended up solving all problems of the given index across all years in the repository.