### PR TITLE
Fix bug where specifying a single year loads all years instead of the specified one.

### DIFF
--- a/src/Runner/Program.cs
+++ b/src/Runner/Program.cs
@@ -40,7 +40,7 @@ else if (args.Length == 1)
         {
             opt.ShowConstructorElapsedTime = true;
             opt.ShowTotalElapsedTimePerDay = true;
-            opt.ProblemAssemblies = [.. assembliesByYear.Values, .. opt.ProblemAssemblies];
+            opt.ProblemAssemblies = [.. yearAssemblies, .. opt.ProblemAssemblies];
         });
     }
 }


### PR DESCRIPTION
This fix resolves an issue where providing a single year as input would incorrectly load assemblies for all years instead of limiting to the specified year. 